### PR TITLE
fix: improve settlement data fetching resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# Nouns Settle Dash
+# Nouns Settler Dashboard
 
-A minimal static landing page that says hello to the world.
+Static dashboard that visualizes who has been settling Nouns auctions and how often.
+
+## Data sources
+
+* [Nouns DAO subgraph](https://thegraph.com/hosted-service/subgraph/nounsdao/nouns-subgraph) – settlement data indexed from the Nouns Auction House contract (`0x830BD73E4184ceF73443C15111a1DF14e495C706`).
+* [ENS Ideas resolver](https://ensideas.com/) – resolves settlement addresses to ENS names when available.
 
 ## Development
 
-Open `index.html` in your browser to view the site.
+Serve the project locally (for example with `python3 -m http.server`) and open `index.html` in your browser.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
       <div class="title-block">
         <h1>Nouns Settler Dashboard</h1>
         <p>Follow every settled Noun auction and who closed it out.</p>
+        <p class="data-source">
+          Tracking settlements from
+          <a
+            id="auction-house-link"
+            href="https://etherscan.io/address/0x830BD73E4184ceF73443C15111a1DF14e495C706"
+            rel="noopener noreferrer"
+            target="_blank"
+          ></a>
+        </p>
       </div>
       <div class="status" id="status">Loading settlement data…</div>
     </header>
@@ -102,6 +111,7 @@
     </template>
 
     <script type="module">
+      const AUCTION_HOUSE_ADDRESS = "0x830BD73E4184ceF73443C15111a1DF14e495C706";
       const GRAPH_ENDPOINTS = [
         {
           url: "https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph",
@@ -127,6 +137,7 @@
       const FETCH_TIMEOUT_MS = 20000;
 
       const statusEl = document.getElementById("status");
+      const auctionHouseLink = document.getElementById("auction-house-link");
       const leaderboardBody = document.getElementById("leaderboard-body");
       const nounGrid = document.getElementById("noun-grid");
       const nounTemplate = document.getElementById("noun-card-template");
@@ -135,6 +146,12 @@
       const highestSettlementEl = document.getElementById("highest-settlement");
 
       const ensCache = new Map();
+
+      function initializeContractLink() {
+        if (!auctionHouseLink) return;
+        auctionHouseLink.textContent = AUCTION_HOUSE_ADDRESS;
+        auctionHouseLink.href = `https://etherscan.io/address/${AUCTION_HOUSE_ADDRESS}`;
+      }
 
       function setStatus(message, isError = false, detail = "") {
         statusEl.textContent = message;
@@ -464,6 +481,7 @@
       }
 
       async function bootstrap() {
+        initializeContractLink();
         try {
           setStatus("Loading settlement data…");
           const rawAuctions = await fetchSettledAuctions();

--- a/index.html
+++ b/index.html
@@ -3,13 +3,499 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Nouns Settle Dash</title>
+    <title>Nouns Settler Dashboard</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main class="hero">
-      <h1>Hello, World!</h1>
-      <p>Welcome to the freshly deployed Nouns Settle Dash site.</p>
+    <header class="page-header">
+      <div class="title-block">
+        <h1>Nouns Settler Dashboard</h1>
+        <p>Follow every settled Noun auction and who closed it out.</p>
+      </div>
+      <div class="status" id="status">Loading settlement data…</div>
+    </header>
+
+    <main>
+      <section class="panel">
+        <h2>At a glance</h2>
+        <div class="stats-grid">
+          <article class="stat-card">
+            <span class="stat-label">Total nouns settled</span>
+            <span class="stat-value" id="total-nouns">—</span>
+          </article>
+          <article class="stat-card">
+            <span class="stat-label">Unique settlers</span>
+            <span class="stat-value" id="unique-settlers">—</span>
+          </article>
+          <article class="stat-card">
+            <span class="stat-label">Highest settlement (ETH)</span>
+            <span class="stat-value" id="highest-settlement">—</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <h2>Leaderboard</h2>
+          <p class="panel-subtitle">
+            Ranked by the number of Noun auctions a wallet has settled. ENS names
+            are shown when available.
+          </p>
+        </div>
+        <div class="table-wrapper">
+          <table class="leaderboard" aria-describedby="leaderboard-caption">
+            <caption id="leaderboard-caption" class="sr-only">
+              Leaderboard of wallets with the most settled Noun auctions.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Settler</th>
+                <th scope="col">Settled</th>
+              </tr>
+            </thead>
+            <tbody id="leaderboard-body">
+              <tr>
+                <td colspan="3" class="placeholder">Loading…</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <h2>Settlements by Noun</h2>
+          <p class="panel-subtitle">
+            Explore each Noun, the wallet that settled it, and key auction
+            details.
+          </p>
+        </div>
+        <div id="noun-grid" class="noun-grid" role="list"></div>
+      </section>
     </main>
+
+    <template id="noun-card-template">
+      <article class="noun-card" role="listitem">
+        <header class="noun-card__header">
+          <img class="noun-card__image" alt="" loading="lazy" />
+          <div>
+            <h3 class="noun-card__title"></h3>
+            <p class="noun-card__subtitle"></p>
+          </div>
+        </header>
+        <dl class="noun-card__meta">
+          <div>
+            <dt>Settled by</dt>
+            <dd><span class="address-label"></span></dd>
+          </div>
+          <div>
+            <dt>Amount</dt>
+            <dd class="noun-card__amount"></dd>
+          </div>
+          <div>
+            <dt>Settled on</dt>
+            <dd class="noun-card__date"></dd>
+          </div>
+        </dl>
+      </article>
+    </template>
+
+    <script type="module">
+      const GRAPH_ENDPOINTS = [
+        {
+          url: "https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph",
+          pageSize: 200,
+          methods: ["GET", "POST"],
+        },
+        {
+          url: "https://api.goldsky.com/api/public/project_clhg0hjfc02ns01xfb2dj26g6/subgraphs/nouns-subgraph/0.0.5/gn",
+          pageSize: 200,
+          methods: ["POST", "GET"],
+        },
+        {
+          url: "https://api.studio.thegraph.com/query/44954/nouns-mainnet/version/latest",
+          pageSize: 200,
+          methods: ["POST"],
+        },
+      ];
+      const ENS_RESOLVER_URL = "https://api.ensideas.com/ens/resolve/";
+      const MAX_PAGES = 20;
+      const WEI_PER_ETH = 10n ** 18n;
+      const GRAPH_QUERY =
+        "query SettledAuctions($first:Int!,$skip:Int!){auctions(first:$first,skip:$skip,orderBy:nounId,orderDirection:asc,where:{settled:true}){nounId amount endTime settled winner{id ens} bidder{id ens}}}";
+      const FETCH_TIMEOUT_MS = 20000;
+
+      const statusEl = document.getElementById("status");
+      const leaderboardBody = document.getElementById("leaderboard-body");
+      const nounGrid = document.getElementById("noun-grid");
+      const nounTemplate = document.getElementById("noun-card-template");
+      const totalNounsEl = document.getElementById("total-nouns");
+      const uniqueSettlersEl = document.getElementById("unique-settlers");
+      const highestSettlementEl = document.getElementById("highest-settlement");
+
+      const ensCache = new Map();
+
+      function setStatus(message, isError = false, detail = "") {
+        statusEl.textContent = message;
+        statusEl.classList.toggle("status--error", isError);
+        statusEl.title = detail && isError ? detail : "";
+      }
+
+      function truncateAddress(address) {
+        if (!address) return "—";
+        return `${address.slice(0, 6)}…${address.slice(-4)}`;
+      }
+
+      function formatEth(value) {
+        if (!value) return "—";
+        try {
+          const raw = BigInt(value);
+          const whole = raw / WEI_PER_ETH;
+          const fraction = raw % WEI_PER_ETH;
+          const fractionStr = fraction
+            .toString()
+            .padStart(18, "0")
+            .slice(0, 4)
+            .replace(/0+$/, "");
+          return `${whole.toString()}${fractionStr ? "." + fractionStr : ""} ETH`;
+        } catch (error) {
+          return "—";
+        }
+      }
+
+      function formatDate(timestamp) {
+        if (!timestamp) return "—";
+        const numeric = Number(timestamp) * 1000;
+        if (!Number.isFinite(numeric)) return "—";
+        const date = new Date(numeric);
+        if (Number.isNaN(date.getTime())) return "—";
+        return date.toLocaleString(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        });
+      }
+
+      function applyEnsLabels(root = document) {
+        root.querySelectorAll("[data-address]").forEach((element) => {
+          const address = element.dataset.address?.toLowerCase();
+          if (!address) return;
+          const ens = ensCache.get(address);
+          element.textContent = ens ?? truncateAddress(address);
+          element.title = ens ? `${ens} (${address})` : address;
+        });
+      }
+
+      async function fetchSettledAuctions() {
+        const endpointErrors = [];
+
+        for (const endpoint of GRAPH_ENDPOINTS) {
+          try {
+            const auctions = await fetchFromEndpoint(endpoint);
+            if (auctions.length) {
+              if (endpointErrors.length) {
+                console.warn("Recovered from earlier Graph endpoint errors:", endpointErrors);
+              }
+              return auctions;
+            }
+            if (!endpointErrors.length) {
+              return auctions;
+            }
+          } catch (error) {
+            console.warn(`Graph endpoint failed: ${endpoint.url}`, error);
+            endpointErrors.push({ url: endpoint.url, message: error?.message ?? String(error) });
+          }
+        }
+
+        const details = endpointErrors
+          .map((entry) => `• ${entry.url}: ${entry.message}`)
+          .join("\n");
+        throw new Error(`All settlement data sources failed.\n${details}`);
+      }
+
+      async function fetchFromEndpoint(endpoint) {
+        const auctions = [];
+        const pageSize = endpoint.pageSize ?? 200;
+
+        for (let page = 0; page < MAX_PAGES; page += 1) {
+          const variables = { first: pageSize, skip: page * pageSize };
+          const payload = await requestGraph(endpoint, variables);
+          if (payload.errors?.length) {
+            const message = payload.errors.map((err) => err.message).join("; ");
+            throw new Error(message || "GraphQL response contained errors");
+          }
+
+          const pageAuctions = payload?.data?.auctions ?? [];
+          auctions.push(...pageAuctions);
+
+          if (pageAuctions.length < pageSize) {
+            break;
+          }
+        }
+
+        return auctions.filter((auction) => auction.settled);
+      }
+
+      async function requestGraph(endpoint, variables) {
+        const methods = endpoint.methods ?? ["GET", "POST"];
+        const errors = [];
+
+        for (const method of methods) {
+          try {
+            const response = await performGraphRequest(endpoint, variables, method);
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status} ${response.statusText}`);
+            }
+            return response.json();
+          } catch (error) {
+            errors.push({ method, message: error?.message ?? String(error) });
+          }
+        }
+
+        const detail = errors.map((entry) => `${entry.method}: ${entry.message}`).join("; ");
+        throw new Error(detail);
+      }
+
+      function performGraphRequest(endpoint, variables, method) {
+        if (method === "GET") {
+          const url = new URL(endpoint.url);
+          url.searchParams.set("query", GRAPH_QUERY);
+          url.searchParams.set("variables", JSON.stringify(variables));
+          return fetchWithTimeout(url.toString(), {
+            method: "GET",
+            mode: "cors",
+            credentials: "omit",
+            cache: "no-store",
+          });
+        }
+
+        if (method === "POST") {
+          return fetchWithTimeout(endpoint.url, {
+            method: "POST",
+            mode: "cors",
+            credentials: "omit",
+            cache: "no-store",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query: GRAPH_QUERY, variables }),
+          });
+        }
+
+        throw new Error(`Unsupported method ${method}`);
+      }
+
+      async function fetchWithTimeout(resource, options = {}) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+        try {
+          const response = await fetch(resource, { ...options, signal: controller.signal });
+          return response;
+        } finally {
+          clearTimeout(timeout);
+        }
+      }
+
+      function processAuctions(rawAuctions) {
+        const processed = [];
+        const leaderboardMap = new Map();
+        let highestSale = 0n;
+
+        rawAuctions.forEach((auction) => {
+          const nounId = Number(auction.nounId);
+          const winner = auction.winner ?? auction.bidder ?? null;
+          const address = winner?.id?.toLowerCase();
+          const ens = winner?.ens ?? null;
+          const amount = auction.amount ?? "0";
+          const endTime = auction.endTime ?? null;
+
+          if (address && !ensCache.has(address)) {
+            ensCache.set(address, ens);
+          }
+
+          if (address) {
+            const item = leaderboardMap.get(address) ?? {
+              address,
+              count: 0,
+              ens: ens ?? null,
+            };
+            item.count += 1;
+            if (ens && !item.ens) {
+              item.ens = ens;
+            }
+            leaderboardMap.set(address, item);
+          }
+
+          try {
+            const wei = BigInt(amount);
+            if (wei > highestSale) {
+              highestSale = wei;
+            }
+          } catch (error) {
+            // Ignore parsing issues for the max tracker.
+          }
+
+          processed.push({
+            nounId,
+            address,
+            ens,
+            amount,
+            endTime,
+          });
+        });
+
+        return {
+          auctions: processed.sort((a, b) => a.nounId - b.nounId),
+          leaderboard: Array.from(leaderboardMap.values()).sort((a, b) => {
+            if (b.count !== a.count) return b.count - a.count;
+            return a.address.localeCompare(b.address);
+          }),
+          highestSale,
+        };
+      }
+
+      function renderStats(total, unique, highestSale) {
+        totalNounsEl.textContent = total.toLocaleString();
+        uniqueSettersText(uniqueSettlersEl, unique);
+        highestSettlementEl.textContent = formatEth(highestSale.toString());
+      }
+
+      function uniqueSettersText(element, value) {
+        element.textContent = value.toLocaleString();
+      }
+
+      function renderLeaderboard(entries) {
+        if (!entries.length) {
+          leaderboardBody.innerHTML =
+            '<tr><td colspan="3" class="placeholder">No settled auctions found.</td></tr>';
+          return;
+        }
+
+        leaderboardBody.innerHTML = "";
+        const fragment = document.createDocumentFragment();
+
+        entries.forEach((entry, index) => {
+          const row = document.createElement("tr");
+
+          const rankCell = document.createElement("td");
+          rankCell.textContent = String(index + 1);
+          row.appendChild(rankCell);
+
+          const addressCell = document.createElement("td");
+          const label = document.createElement("span");
+          label.className = "address-label";
+          label.dataset.address = entry.address;
+          addressCell.appendChild(label);
+          row.appendChild(addressCell);
+
+          const countCell = document.createElement("td");
+          countCell.textContent = entry.count.toLocaleString();
+          row.appendChild(countCell);
+
+          fragment.appendChild(row);
+        });
+
+        leaderboardBody.appendChild(fragment);
+        applyEnsLabels(leaderboardBody);
+      }
+
+      function renderNouns(auctions) {
+        nounGrid.innerHTML = "";
+        const fragment = document.createDocumentFragment();
+
+        auctions.forEach((auction) => {
+          const { nounId, address, ens, amount, endTime } = auction;
+          const instance = nounTemplate.content.cloneNode(true);
+          const card = instance.querySelector(".noun-card");
+          const image = instance.querySelector(".noun-card__image");
+          const title = instance.querySelector(".noun-card__title");
+          const subtitle = instance.querySelector(".noun-card__subtitle");
+          const addressLabel = instance.querySelector(".address-label");
+          const amountEl = instance.querySelector(".noun-card__amount");
+          const dateEl = instance.querySelector(".noun-card__date");
+
+          image.src = `https://noun.pics/${nounId}.png`;
+          image.alt = `Noun ${nounId}`;
+          title.textContent = `Noun #${nounId}`;
+          subtitle.textContent = address
+            ? "Settled auction"
+            : "Settler unavailable";
+
+          if (address) {
+            addressLabel.dataset.address = address;
+          } else {
+            addressLabel.textContent = "—";
+          }
+
+          amountEl.textContent = formatEth(amount);
+          dateEl.textContent = formatDate(endTime);
+
+          fragment.appendChild(instance);
+        });
+
+        nounGrid.appendChild(fragment);
+        applyEnsLabels(nounGrid);
+      }
+
+      async function resolveEnsNames(addresses) {
+        const unique = Array.from(new Set(addresses.map((addr) => addr?.toLowerCase()).filter(Boolean)));
+        const queue = unique.filter((address) => !ensCache.has(address));
+        if (!queue.length) return;
+
+        const concurrency = 4;
+        const workers = new Array(concurrency).fill(null).map(async () => {
+          while (queue.length) {
+            const address = queue.shift();
+            if (!address) return;
+            try {
+              const response = await fetch(`${ENS_RESOLVER_URL}${address}`);
+              if (!response.ok) {
+                ensCache.set(address, null);
+                continue;
+              }
+              const data = await response.json();
+              const name = data?.name ?? null;
+              ensCache.set(address, name);
+            } catch (error) {
+              ensCache.set(address, null);
+            }
+          }
+        });
+
+        await Promise.all(workers);
+      }
+
+      async function bootstrap() {
+        try {
+          setStatus("Loading settlement data…");
+          const rawAuctions = await fetchSettledAuctions();
+          if (!rawAuctions.length) {
+            setStatus("No settled auctions found yet.");
+            renderStats(0, 0, 0n);
+            renderLeaderboard([]);
+            renderNouns([]);
+            return;
+          }
+
+          const { auctions, leaderboard, highestSale } = processAuctions(rawAuctions);
+
+          renderStats(auctions.length, leaderboard.length, highestSale);
+          renderLeaderboard(leaderboard);
+          renderNouns(auctions);
+
+          const topAddresses = leaderboard.slice(0, 50).map((entry) => entry.address);
+          await resolveEnsNames(topAddresses);
+          applyEnsLabels();
+
+          setStatus(
+            `Loaded ${auctions.length.toLocaleString()} settlements · Last updated ${new Date().toLocaleTimeString()}`,
+          );
+        } catch (error) {
+          console.error(error);
+          const detail = error?.message ?? String(error);
+          setStatus("We couldn’t load data from the network. Please try again later.", true, detail);
+        }
+      }
+
+      bootstrap();
+    </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,33 +1,310 @@
 :root {
   color-scheme: light dark;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
     sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  display: grid;
-  place-items: center;
-  background: linear-gradient(135deg, #fdfbfb, #ebedee);
+  background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+  color: #0f172a;
+  display: flex;
+  flex-direction: column;
 }
 
-.hero {
-  text-align: center;
-  padding: 4rem 2rem;
-  border-radius: 1.5rem;
-  background-color: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 1.5rem 3rem -1rem rgba(15, 23, 42, 0.2);
+.page-header {
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 4vw, 3rem);
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem 2rem;
 }
 
-.hero h1 {
-  font-size: clamp(2.5rem, 8vw, 4rem);
-  margin: 0 0 1rem;
-  color: #111827;
-}
-
-.hero p {
-  font-size: clamp(1.125rem, 4vw, 1.5rem);
+.title-block h1 {
   margin: 0;
-  color: #374151;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: #0f172a;
+}
+
+.title-block p {
+  margin: 0.25rem 0 0;
+  max-width: 40rem;
+  color: #475569;
+}
+
+.status {
+  margin-left: auto;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.status--error {
+  color: #dc2626;
+}
+
+main {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 3vw, 3rem) clamp(1rem, 3vw, 2.5rem) 4rem;
+  display: grid;
+  gap: clamp(1.5rem, 2.5vw, 2.5rem);
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 1.25rem;
+  box-shadow: 0 25px 60px -30px rgba(15, 23, 42, 0.35);
+  padding: clamp(1.5rem, 2.5vw, 2.5rem);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  color: #0f172a;
+}
+
+.panel-subtitle {
+  margin: 0.25rem 0 0;
+  color: #475569;
+  max-width: 45rem;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-card {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0));
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #1d4ed8;
+}
+
+.stat-value {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.leaderboard {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.leaderboard thead th {
+  text-align: left;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding-bottom: 0.75rem;
+}
+
+.leaderboard tbody td {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.leaderboard tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.leaderboard tbody tr:hover {
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.placeholder {
+  text-align: center;
+  padding: 1rem 0;
+  color: #64748b;
+}
+
+.address-label {
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, "SFMono-Regular",
+    Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.noun-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.noun-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.noun-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 30px -20px rgba(15, 23, 42, 0.5);
+}
+
+.noun-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.noun-card__image {
+  width: 72px;
+  height: 72px;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: #fff;
+}
+
+.noun-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.noun-card__subtitle {
+  margin: 0.15rem 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.noun-card__meta {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.noun-card__meta div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.noun-card__meta dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.noun-card__meta dd {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.noun-card__amount {
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, "SFMono-Regular",
+    Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    align-items: flex-start;
+  }
+
+  .status {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: radial-gradient(circle at top, #020617, #0f172a 55%, #020617 100%);
+    color: #e2e8f0;
+  }
+
+  .page-header,
+  .panel {
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    box-shadow: 0 25px 60px -35px rgba(2, 6, 23, 0.8);
+  }
+
+  .title-block h1,
+  .panel-heading h2,
+  .stat-value,
+  .noun-card__title,
+  .noun-card__meta dd {
+    color: #e2e8f0;
+  }
+
+  .title-block p,
+  .panel-subtitle,
+  .stat-label,
+  .leaderboard thead th,
+  .noun-card__subtitle,
+  .noun-card__meta dt {
+    color: #cbd5f5;
+  }
+
+  .status {
+    color: #93c5fd;
+  }
+
+  .status--error {
+    color: #f87171;
+  }
+
+  .noun-card {
+    background: rgba(15, 23, 42, 0.6);
+    border-color: rgba(148, 163, 184, 0.18);
+  }
+
+  .address-label,
+  .noun-card__amount {
+    color: #f8fafc;
+  }
+
+  .leaderboard tbody tr:hover {
+    background: rgba(59, 130, 246, 0.12);
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,18 @@ body {
   color: #475569;
 }
 
+.data-source {
+  margin-top: 0.5rem;
+  font-size: 0.9375rem;
+  color: #475569;
+}
+
+.data-source a {
+  color: inherit;
+  text-decoration: underline;
+  word-break: break-all;
+}
+
 .status {
   margin-left: auto;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add multiple graph endpoints with GET/POST fallback to avoid cors blocks when loading settlement data
- add a request timeout helper and retry logic to collect settled auctions page by page
- surface detailed error messages in the dashboard status indicator when data fetching fails

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e15982cdd8832c9f9f5d4325c94b29